### PR TITLE
Diagramm zoombar

### DIFF
--- a/src/main/resources/static/js/umlcd.js
+++ b/src/main/resources/static/js/umlcd.js
@@ -1,11 +1,12 @@
 var uigraph = new joint.dia.Graph();
 
 var uipaperWidth = 200;
+var uipaperHeight = 600;
 
 var uipaper = new joint.dia.Paper({
     el: $('#uipaper'),
     width: uipaperWidth,
-    height: 800,
+    height: uipaperHeight,
     gridSize: 1,
     model: uigraph
 });
@@ -118,6 +119,7 @@ var uipaper = new joint.dia.Paper({
                 var val = $(evt.target).val();
                 this.$box.find('span').text(val+'%');
                 paper.scale(val/100, val/100);
+                paper.fitToContent({allowNewOrigin:'any'});
 
             } , this));
 
@@ -230,11 +232,17 @@ var graph = new joint.dia.Graph();
 
 var paper = new joint.dia.Paper({
     el: $('#paper'),
-    width: window.innerWidth-uipaperWidth-200,
+    width: window.innerWidth,
     height: window.innerHeight,
     gridSize: 1,
     model: graph
 });
+
+graph.on('change:position', function(cell, newPosition, opt) {
+paper.fitToContent({allowNewOrigin:'any'});
+
+});
+paper.fitToContent();
 
 var uml = joint.shapes.uml;
 
@@ -438,7 +446,7 @@ _.each(relations, function (r) {
 });
 
 
-
+paper.fitToContent();
 
 
 var createOffset = 0;
@@ -514,7 +522,7 @@ paper.on('cell:pointerup',
 
         serialize();
 
-    }
+}
 );
 
 database.ref().on('value', function(snapshot) {
@@ -523,6 +531,7 @@ database.ref().on('value', function(snapshot) {
         graph.fromJSON(JSON.parse(jsonFromFirebase));
 
     }
+    paper.fitToContent({allowNewOrigin:'any'})
 });
 
 
@@ -567,8 +576,9 @@ function share() {
 }
 function upload() {
 }
-function download() {
-}
+
+
+
 
 function serialize() {
         var json = JSON.stringify(graph);
@@ -576,3 +586,4 @@ function serialize() {
         databaseObject[uniqueID] = json;
         database.ref().set(databaseObject);
         }
+

--- a/src/main/resources/static/js/umlcd.js
+++ b/src/main/resources/static/js/umlcd.js
@@ -53,11 +53,15 @@ var uipaper = new joint.dia.Paper({
             '<textarea id="Attribute"></textarea>',
             '<textarea id="Methoden"></textarea>',
             '<button class="klasseaendern">Aendern</button>','<br/>',
+            '<p><p/>',
             '<label id="Assoziation"></label>',
             '<textarea id="Assoziationsname"></textarea>',
             '<textarea id="KardinalitaetQuelle"></textarea>',
             '<textarea id="KardinalitaetZiel"></textarea>',
-            '<button class="assoziationaendern">Aendern</button>',
+            '<button class="assoziationaendern">Aendern</button>','<br/>',
+            '<p><p/>',
+            '<label id="Zoom">Zoom</label>','<br/>',
+            '<input id="Zoom" type="range" min="10" max="200" value="100" step="10" />',
 
             '</div>'
         ].join(''),
@@ -107,7 +111,17 @@ var uipaper = new joint.dia.Paper({
 
                 this.model.set('kardinalitaetZiel', $(evt.target).val());
 
-            }, this));
+            },this));
+            this.$box.find('#Zoom').on('change',_.bind(function (evt) {
+                var val = $(evt.target).val()/100;
+                paper.scale(val, val);
+
+            } , this));
+
+
+
+
+
 
 
             this.$box.find('.klasseaendern').on('click', _.bind(function () {

--- a/src/main/resources/static/js/umlcd.js
+++ b/src/main/resources/static/js/umlcd.js
@@ -60,8 +60,9 @@ var uipaper = new joint.dia.Paper({
             '<textarea id="KardinalitaetZiel"></textarea>',
             '<button class="assoziationaendern">Aendern</button>','<br/>',
             '<p><p/>',
-            '<label id="Zoom">Zoom</label>','<br/>',
+            '<label id="Zoom">Zoom:</label>','<span id="Range">100%</span>','<br/>',
             '<input id="Zoom" type="range" min="10" max="200" value="100" step="10" />',
+
 
             '</div>'
         ].join(''),
@@ -113,8 +114,10 @@ var uipaper = new joint.dia.Paper({
 
             },this));
             this.$box.find('#Zoom').on('change',_.bind(function (evt) {
-                var val = $(evt.target).val()/100;
-                paper.scale(val, val);
+
+                var val = $(evt.target).val();
+                this.$box.find('span').text(val+'%');
+                paper.scale(val/100, val/100);
 
             } , this));
 

--- a/src/main/resources/static/js/umlcd.js
+++ b/src/main/resources/static/js/umlcd.js
@@ -119,7 +119,7 @@ var uipaper = new joint.dia.Paper({
                 var val = $(evt.target).val();
                 this.$box.find('span').text(val+'%');
                 paper.scale(val/100, val/100);
-                paper.fitToContent({allowNewOrigin:'any'});
+                paper.fitToContent({allowNewOrigin:'negative'});
 
             } , this));
 
@@ -239,10 +239,10 @@ var paper = new joint.dia.Paper({
 });
 
 graph.on('change:position', function(cell, newPosition, opt) {
-paper.fitToContent({allowNewOrigin:'any'});
+paper.fitToContent({allowNewOrigin:'negative'});
 
 });
-paper.fitToContent();
+
 
 var uml = joint.shapes.uml;
 
@@ -446,7 +446,7 @@ _.each(relations, function (r) {
 });
 
 
-paper.fitToContent();
+paper.fitToContent({allowNewOrigin:'negative'});
 
 
 var createOffset = 0;
@@ -531,7 +531,7 @@ database.ref().on('value', function(snapshot) {
         graph.fromJSON(JSON.parse(jsonFromFirebase));
 
     }
-    paper.fitToContent({allowNewOrigin:'any'})
+    paper.fitToContent({allowNewOrigin:'negative'})
 });
 
 

--- a/src/main/resources/templates/commuml-draw.html
+++ b/src/main/resources/templates/commuml-draw.html
@@ -73,9 +73,7 @@
     </li>
     <li>
         <div class="logo">
-            <a id="downloadButton" href="javascript:download();" download="UML-JSON">
-            <img src="/images/DownloadButton.png" alt="Herunterladen" title="Herunterladen"/>
-            </a>
+            <img src="/images/DownloadButton.png" onclick="download()" alt="Herunterladen" title="Herunterladen"/>
         </div>
     </li>
     <li>

--- a/src/main/resources/templates/commuml-draw.html
+++ b/src/main/resources/templates/commuml-draw.html
@@ -6,8 +6,18 @@
     <title>CommUML v1.0</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <style>
-        #paper { float: left; }
-        #uipaper { float: right; }
+        #paper { float: left;
+        height:90vh;
+        width: -moz-calc(100% - 200px);
+        width: -webkit-calc(100% - 200px);
+        width: calc(100% - 200px);
+        overflow-x:scroll;
+        margin-top: 60px;
+        }
+        #uipaper { float: right;
+         margin-top: 60px;}
+
+
 
     </style>
 </head>
@@ -63,7 +73,9 @@
     </li>
     <li>
         <div class="logo">
-            <img src="/images/DownloadButton.png" onclick="download()" alt="Herunterladen" title="Herunterladen"/>
+            <a id="downloadButton" href="javascript:download();" download="UML-JSON">
+            <img src="/images/DownloadButton.png" alt="Herunterladen" title="Herunterladen"/>
+            </a>
         </div>
     </li>
     <li>
@@ -71,7 +83,7 @@
     </li>
 </ul>
 <input type="hidden" id="uniqeIdStore" value="${id}" th:value="${id}"/>
-<div id="paper" style="margin-top: 60px;"></div><div id="uipaper" style="margin-top: 60px;"></div>
+<div id="paper" ></div><div id="uipaper" ></div>
 
 <script src="/js/jquery.js"></script>
 <script src="/js/lodash.js"></script>


### PR DESCRIPTION
So, jetzt auch vernünftig zoombar.
- Das Zoomen und das Verschieben von Elementen skaliert jetzt automatisch das Paper
-> heißt, es wird nichts mehr "aus dem Bild" geschoben, das Paper kann also prinzipiell unendlich groß werden (falls eher ungünstig kann man auch noch eine Maximalgröße definieren, über die nicht hinaus skaliert wird)
- Dabei erhält das Diagramm-Paper (unabhängig von der Property Box) eigene Scroll-Balken
- Netter Seiteneffekt: Das Verändern der Fenstergröße des Browsers/die Auflösung des Clientbrowsers hat keinen Einfluss mehr auf die Größe des Papers
